### PR TITLE
Update Tisseo API to v2

### DIFF
--- a/MMM-Toulouse-Transports.js
+++ b/MMM-Toulouse-Transports.js
@@ -32,7 +32,7 @@ Module.register( "MMM-Toulouse-Transports", {
         animationSpeed: 2000,
         convertToWaitingTime: true, // messages received from API can be 'hh:mm' in that case convert it in the waiting time 'x mn'
         initialLoadDelay: 0, // start delay seconds.
-        apiBaseSchedules: 'https://api.tisseo.fr/v1/stops_schedules.json?',
+        apiBaseSchedules: 'https://api.tisseo.fr/v2/stops_schedules.json?',
         maxLettersForDestination: 22, //will limit the length of the destination string
         concatenateArrivals: true, //if for a transport there is the same destination and several times, they will be displayed on one line
         showSecondsToNextUpdate: true, // display a countdown to the next update pull (should I wait for a refresh before going ?)

--- a/node_helper.js
+++ b/node_helper.js
@@ -131,7 +131,7 @@ module.exports = NodeHelper.create( {
             var lineShortName = self.config.stopSchedules[index].lineNumber;
             self.log(DEBUG, "updateLineInfo - iteration:" + index +" get Line data for: " + lineShortName);
 
-            var urlGetLineId = 'https://api.tisseo.fr/v1/lines.json?network=Tiss%C3%A9o&shortName='+ lineShortName +'&key=' + apiKey;
+            var urlGetLineId = 'https://api.tisseo.fr/v2/lines.json?network=Tiss%C3%A9o&shortName='+ lineShortName +'&key=' + apiKey;
 
             unirest.get( urlGetLineId )
                 .headers( { 'Accept': 'text/html,application/xhtml+xml,application/xml;charset=utf-8' } )
@@ -172,7 +172,7 @@ module.exports = NodeHelper.create( {
         this.log(TRACE, "updateStopInfo - start - stopCode="+stopCode+" - lineId="+lineId);
         var self = this;
         var apiKey = self.config.apiKey;
-        var urlAllStop = 'https://api.tisseo.fr/v1/stop_points.json?lineId=' + lineId +'&key=' + apiKey;
+        var urlAllStop = 'https://api.tisseo.fr/v2/stop_points.json?lineId=' + lineId +'&key=' + apiKey;
         unirest.get( urlAllStop )
             .headers( {'Accept': 'text/html,application/xhtml+xml,application/xml;charset=utf-8'} )
             .end( function ( response ) {


### PR DESCRIPTION
Tisseo API v1 doesn't work anymore.

v2 API seems to be compatible so I just changed the 'v1' in the URLs by 'v2' and it seems to work.